### PR TITLE
Improve AngellEye Updater UX and Add Latest Version Column

### DIFF
--- a/admin/class-angelleye-updater-admin.php
+++ b/admin/class-angelleye-updater-admin.php
@@ -944,7 +944,7 @@ class AngellEYE_Updater_Admin {
         foreach ($angelleye_plugin_full_list as $plugin_key => $v) {
             $is_insatlled = $this->angelleye_is_plugin_installed($plugin_key);
             $installed_version = '-';
-            $latest_version = $this->angelleye_get_latest_plugin_version($v['plugin_url']);
+            $latest_version = $this->angelleye_get_latest_plugin_version($plugin_key);
             $product_status = 'in-active';
             $license_key = '';
             $plugin_status = 'Not Installed';
@@ -970,7 +970,7 @@ class AngellEYE_Updater_Admin {
                 'installed_version' => $installed_version,
                 'latest_version' => $latest_version,
                 'file_id' => 999,
-                'product_id' => sanitize_key($v['plugin_url']),
+                'product_id' => sanitize_key($plugin_key),
                 'product_status' => $product_status,
                 'product_file_path' => $product_file_path,
                 'license_key' => $license_key,
@@ -1024,14 +1024,23 @@ class AngellEYE_Updater_Admin {
     }
 
     public function angelleye_get_latest_plugin_version($product_id, $product_file_path = '') {
-        $product_id = sanitize_key($product_id);
+        $product_id = $this->angelleye_resolve_plugin_list_key($product_id);
         $latest_versions = $this->angelleye_get_cached_latest_versions();
         if (isset($latest_versions[$product_id]) && !empty($latest_versions[$product_id]) && '-' !== $latest_versions[$product_id]) {
             return $latest_versions[$product_id];
         }
 
+        $plugin_definition = $this->angelleye_get_plugin_definition($product_id);
+        if ($plugin_definition && isset($plugin_definition['plugin_url'])) {
+            $legacy_id = sanitize_key($plugin_definition['plugin_url']);
+            if (isset($latest_versions[$legacy_id]) && !empty($latest_versions[$legacy_id]) && '-' !== $latest_versions[$legacy_id]) {
+                return $latest_versions[$legacy_id];
+            }
+        }
+
         if (empty($product_file_path)) {
-            $plugin = $this->angelleye_find_plugin_by_product_id($product_id);
+            $plugin_lookup_id = ($plugin_definition && isset($plugin_definition['plugin_url'])) ? $plugin_definition['plugin_url'] : $product_id;
+            $plugin = $this->angelleye_find_plugin_by_product_id($plugin_lookup_id);
             if (!$plugin || empty($plugin['file'])) {
                 return '-';
             }
@@ -1087,11 +1096,36 @@ class AngellEYE_Updater_Admin {
         set_transient('angelleye_helper_latest_versions', $latest_versions, 7 * DAY_IN_SECONDS);
     }
 
+    private function angelleye_resolve_plugin_list_key($product_id) {
+        $plugin_list = angelleye_plugin_list();
+        $normalized = sanitize_key($product_id);
+
+        if (!is_array($plugin_list) || empty($normalized)) {
+            return $normalized;
+        }
+
+        if (isset($plugin_list[$normalized])) {
+            return $normalized;
+        }
+
+        foreach ($plugin_list as $plugin_key => $plugin) {
+            if (isset($plugin['plugin_url']) && sanitize_key($plugin['plugin_url']) === $normalized) {
+                return sanitize_key($plugin_key);
+            }
+        }
+
+        return $normalized;
+    }
+
     private function angelleye_get_plugin_definition($product_id) {
         $plugin_list = angelleye_plugin_list();
-        $normalized_product_id = sanitize_key($product_id);
+        $normalized_product_id = $this->angelleye_resolve_plugin_list_key($product_id);
         if (!is_array($plugin_list) || empty($plugin_list)) {
             return false;
+        }
+
+        if (isset($plugin_list[$normalized_product_id])) {
+            return $plugin_list[$normalized_product_id];
         }
 
         foreach ($plugin_list as $plugin) {
@@ -1114,12 +1148,12 @@ class AngellEYE_Updater_Admin {
             return $candidates;
         }
 
-        foreach ($plugin_list as $plugin) {
+        foreach ($plugin_list as $plugin_key => $plugin) {
             if (!isset($plugin['plugin_url']) || empty($plugin['plugin_url'])) {
                 continue;
             }
 
-            $product_id = sanitize_key($plugin['plugin_url']);
+            $product_id = sanitize_key($plugin_key);
             $has_latest = isset($meta[$product_id]['latest_version']) && '' !== $meta[$product_id]['latest_version'] && '-' !== $meta[$product_id]['latest_version'];
             $last_synced = isset($meta[$product_id]['last_synced']) ? (int) $meta[$product_id]['last_synced'] : 0;
             $is_fresh = $last_synced > 0 && ( $now - $last_synced ) < $fresh_window;
@@ -1133,7 +1167,7 @@ class AngellEYE_Updater_Admin {
     }
 
     private function angelleye_sync_latest_version_for_product($product_id, $force = false) {
-        $product_id = sanitize_key($product_id);
+        $product_id = $this->angelleye_resolve_plugin_list_key($product_id);
         $plugin = $this->angelleye_get_plugin_definition($product_id);
         if (!$plugin) {
             return array(
@@ -1147,25 +1181,27 @@ class AngellEYE_Updater_Admin {
         $now = time();
         $fresh_window = DAY_IN_SECONDS;
 
-        if (!$force && isset($meta[$product_id]['last_synced']) && ( $now - (int) $meta[$product_id]['last_synced'] ) < $fresh_window) {
-            return array(
-                'product_id' => $product_id,
-                'latest_version' => isset($meta[$product_id]['latest_version']) ? $meta[$product_id]['latest_version'] : '-',
-                'status' => 'skipped',
-                'last_synced' => (int) $meta[$product_id]['last_synced'],
-            );
-        }
+        // if (!$force && isset($meta[$product_id]['last_synced']) && ( $now - (int) $meta[$product_id]['last_synced'] ) < $fresh_window) {
+        //     return array(
+        //         'product_id' => $product_id,
+        //         'latest_version' => isset($meta[$product_id]['latest_version']) ? $meta[$product_id]['latest_version'] : '-',
+        //         'status' => 'skipped',
+        //         'last_synced' => (int) $meta[$product_id]['last_synced'],
+        //     );
+        // }
 
-        $product_file_path = $this->angelleye_get_product_file_path($product_id);
-        $current_version = $this->angelleye_get_plugin_version($product_id);
-        $license_data = $this->angelleye_is_key_activated($product_id);
+        $api_product_id = $product_id;
+
+        $product_file_path = $this->angelleye_get_product_file_path($api_product_id);
+        $current_version = $this->angelleye_get_plugin_version($api_product_id);
+        $license_data = $this->angelleye_is_key_activated($api_product_id);
         $license_hash = (is_array($license_data) && isset($license_data[2])) ? $license_data[2] : '';
-        $plugin_name_for_request = !empty($product_file_path) ? $product_file_path : $product_id;
+        $plugin_name_for_request = !empty($product_file_path) ? $product_file_path : $api_product_id;
         $file_id = !empty($license_hash) ? '101' : '999';
 
         $payload = $this->api->angelleye_get_plugin_update_payload(
             $plugin_name_for_request,
-            $product_id,
+            $api_product_id,
             $current_version,
             $file_id,
             $license_hash
@@ -1196,23 +1232,20 @@ class AngellEYE_Updater_Admin {
             return $latest_versions;
         }
 
-        foreach ($plugin_list as $plugin) {
-            if (!isset($plugin['plugin_url'])) {
-                continue;
-            }
+        foreach ($plugin_list as $plugin_key => $plugin) {
+            $product_id = sanitize_key($plugin_key);
+            $api_product_id = sanitize_key($plugin['plugin_url']);
 
-            $product_id = $plugin['plugin_url'];
-            $product_file_path = $this->angelleye_get_product_file_path($product_id);
-            $current_version = $this->angelleye_get_plugin_version($product_id);
-            $license_data = $this->angelleye_is_key_activated($product_id);
+            $product_file_path = $this->angelleye_get_product_file_path($api_product_id);
+            $current_version = $this->angelleye_get_plugin_version($api_product_id);
+            $license_data = $this->angelleye_is_key_activated($api_product_id);
             $license_hash = (is_array($license_data) && isset($license_data[2])) ? $license_data[2] : '';
-
-            $plugin_name_for_request = !empty($product_file_path) ? $product_file_path : $product_id;
+            $plugin_name_for_request = !empty($product_file_path) ? $product_file_path : $api_product_id;
             $file_id = !empty($license_hash) ? '101' : '999';
 
             $payload = $this->api->angelleye_get_plugin_update_payload(
                 $plugin_name_for_request,
-                $product_id,
+                $api_product_id,
                 $current_version == '-' ? '2.0.0' : $current_version,
                 $file_id,
                 $license_hash

--- a/admin/class-angelleye-updater-admin.php
+++ b/admin/class-angelleye-updater-admin.php
@@ -106,6 +106,7 @@ class AngellEYE_Updater_Admin {
         add_action('admin_init', array($this, 'angelleye_cache_refresh'));
 
         add_action('wp_ajax_angelleye_activate_license_keys', array($this, 'ajax_process_request'));
+        add_action('wp_ajax_angelleye_sync_latest_version', array($this, 'ajax_sync_latest_version'));
         add_action('admin_notices', array($this, 'angelleye_check_product_license_key_status'));
     }
 
@@ -212,6 +213,7 @@ class AngellEYE_Updater_Admin {
      * @return   void
      */
     public function settings_screen() {
+        $this->angelleye_maybe_refresh_plugin_updates();
         ?>
         <div id="welcome-panel" class="wrap angelleye-updater-wrap">
             <h1><?php _e('Welcome to Angell EYE Updater', 'angelleye-updater'); ?></h1>
@@ -388,9 +390,12 @@ class AngellEYE_Updater_Admin {
             wp_enqueue_script('post');
             wp_register_script('angelleye-updater-admin', $this->assets_url . 'js/angelleye-updater-admin.js', array('jquery'));
             wp_enqueue_script('angelleye-updater-admin');
+            $sync_candidates = $this->angelleye_get_sync_candidates();
             $localization = array(
                 'ajax_url' => admin_url('admin-ajax.php'),
-                'activate_license_nonce' => wp_create_nonce('activate-license-keys')
+                'activate_license_nonce' => wp_create_nonce('activate-license-keys'),
+                'sync_latest_nonce' => wp_create_nonce('sync-latest-versions'),
+                'sync_candidates' => $sync_candidates,
             );
             wp_localize_script('angelleye-updater-admin', 'WTHelper', $localization);
         }
@@ -506,6 +511,29 @@ class AngellEYE_Updater_Admin {
             echo json_encode($return_json);
         }
         die();
+    }
+
+    public function ajax_sync_latest_version() {
+        if (!current_user_can('update_plugins')) {
+            wp_send_json_error(array('message' => __('Insufficient permissions.', 'angelleye-updater')));
+        }
+
+        $security = isset($_POST['security']) ? sanitize_text_field(wp_unslash($_POST['security'])) : '';
+        if (!wp_verify_nonce($security, 'sync-latest-versions')) {
+            wp_send_json_error(array('message' => __('Invalid request.', 'angelleye-updater')));
+        }
+
+        $product_id = isset($_POST['product_id']) ? sanitize_key(wp_unslash($_POST['product_id'])) : '';
+        if (empty($product_id)) {
+            wp_send_json_error(array('message' => __('Missing product id.', 'angelleye-updater')));
+        }
+
+        $result = $this->angelleye_sync_latest_version_for_product($product_id);
+        if (!is_array($result)) {
+            wp_send_json_error(array('message' => __('Unable to sync version.', 'angelleye-updater')));
+        }
+
+        wp_send_json_success($result);
     }
 
     /**
@@ -794,6 +822,7 @@ class AngellEYE_Updater_Admin {
     public function load_updater_instances() {
         $products = $this->get_detected_products();
         $all_plugins = get_plugins();
+        
         if( !empty($all_plugins) ) {
             foreach ($all_plugins as $key => $plugins) {
                 if( isset($plugins['Author']) && !empty($plugins['Author']) && trim($plugins['Author']) === 'Angell EYE' ) {
@@ -914,14 +943,17 @@ class AngellEYE_Updater_Admin {
         }
         foreach ($angelleye_plugin_full_list as $plugin_key => $v) {
             $is_insatlled = $this->angelleye_is_plugin_installed($plugin_key);
-            $version = '2.0.0';
+            $installed_version = '-';
+            $latest_version = $this->angelleye_get_latest_plugin_version($v['plugin_url']);
             $product_status = 'in-active';
             $license_key = '';
             $plugin_status = 'Not Installed';
             $product_file_path = '';
             if($is_insatlled) {
                 $plugin_status = 'Installed';
-                $version = $this->angelleye_get_plugin_version($v['plugin_url']);
+                $installed_version = $this->angelleye_get_plugin_version($v['plugin_url']);
+                $product_file_path = $this->angelleye_get_product_file_path($v['plugin_url']);
+                $latest_version = $this->angelleye_get_latest_plugin_version($v['plugin_url'], $product_file_path);
                 $is_key_active = $this->angelleye_is_key_activated($v['plugin_url']);
                 if($is_key_active) {
                     $license_key = $is_key_active[2];
@@ -931,34 +963,338 @@ class AngellEYE_Updater_Admin {
                     $license_key = '';
                     $product_status = 'in-active';
                 }
-                $product_file_path = $this->angelleye_get_product_file_path($v['plugin_url']);
             } 
-            $response[$plugin_key] = array('product_name' => $v['plugin_name'], 'product_version' => $version, 'file_id' => 999, 'product_id' => $v['plugin_url'], 'product_status' => $product_status, 'product_file_path' => $product_file_path, 'license_key' => $license_key, 'is_paid' => $v['is_paid'], 'plugin_status' => $plugin_status);
+            $response[$plugin_key] = array(
+                'product_name' => $v['plugin_name'],
+                'product_version' => $installed_version,
+                'installed_version' => $installed_version,
+                'latest_version' => $latest_version,
+                'file_id' => 999,
+                'product_id' => sanitize_key($v['plugin_url']),
+                'product_status' => $product_status,
+                'product_file_path' => $product_file_path,
+                'license_key' => $license_key,
+                'is_paid' => $v['is_paid'],
+                'plugin_status' => $plugin_status
+            );
         }
         return $response;
     }
-    
-    public function angelleye_is_plugin_installed($plugin_name) {
+
+    private function angelleye_find_plugin_by_product_id($product_id) {
         $plugins = get_plugins();
-        if(!empty($plugins)) {
-            foreach ($plugins as $key => $value) {
-                if($value['TextDomain'] == $plugin_name) {
-                    return true;
-                }
+        $normalized_product_id = sanitize_key(strtolower((string) $product_id));
+
+        if (empty($plugins) || empty($normalized_product_id)) {
+            return false;
+        }
+
+        foreach ($plugins as $plugin_file => $plugin_data) {
+            $text_domain = isset($plugin_data['TextDomain']) ? sanitize_key(strtolower((string) $plugin_data['TextDomain'])) : '';
+            $plugin_folder = sanitize_key(strtolower(dirname($plugin_file)));
+            $plugin_basename = sanitize_key(strtolower(basename($plugin_file, '.php')));
+
+            if (
+                $text_domain === $normalized_product_id ||
+                $plugin_folder === $normalized_product_id ||
+                $plugin_basename === $normalized_product_id
+            ) {
+                return array(
+                    'file' => $plugin_file,
+                    'data' => $plugin_data,
+                );
             }
         }
+
         return false;
     }
+    
+    public function angelleye_is_plugin_installed($plugin_name) {
+        return (bool) $this->angelleye_find_plugin_by_product_id($plugin_name);
+    }
+
     public function angelleye_get_plugin_version($plugin_name) {
-        $plugins = get_plugins();
-        if(!empty($plugins)) {
-            foreach ($plugins as $key => $value) {
-                if($value['TextDomain'] == $plugin_name) {
-                    return $value['Version'];
+        $plugin = $this->angelleye_find_plugin_by_product_id($plugin_name);
+
+        if ($plugin && !empty($plugin['data']['Version'])) {
+            return $plugin['data']['Version'];
+        }
+
+        return '-';
+    }
+
+    public function angelleye_get_latest_plugin_version($product_id, $product_file_path = '') {
+        $product_id = sanitize_key($product_id);
+        $latest_versions = $this->angelleye_get_cached_latest_versions();
+        if (isset($latest_versions[$product_id]) && !empty($latest_versions[$product_id]) && '-' !== $latest_versions[$product_id]) {
+            return $latest_versions[$product_id];
+        }
+
+        if (empty($product_file_path)) {
+            $plugin = $this->angelleye_find_plugin_by_product_id($product_id);
+            if (!$plugin || empty($plugin['file'])) {
+                return '-';
+            }
+            $product_file_path = $plugin['file'];
+        }
+
+        $updates = get_site_transient('update_plugins');
+        $version = $this->angelleye_extract_latest_version_from_updates($updates, $product_file_path);
+        if ('-' !== $version) {
+            return $version;
+        }
+
+        $this->angelleye_maybe_refresh_plugin_updates(true);
+        $updates = get_site_transient('update_plugins');
+        return $this->angelleye_extract_latest_version_from_updates($updates, $product_file_path);
+    }
+
+    private function angelleye_get_cached_latest_versions() {
+        $meta = $this->angelleye_get_latest_versions_meta();
+        $latest_versions = array();
+
+        if (!empty($meta) && is_array($meta)) {
+            foreach ($meta as $product_id => $details) {
+                if (isset($details['latest_version'])) {
+                    $latest_versions[sanitize_key($product_id)] = $details['latest_version'];
                 }
             }
+            return $latest_versions;
         }
-        return '2.0.0';
+
+        $legacy_latest_versions = get_transient('angelleye_helper_latest_versions');
+        return is_array($legacy_latest_versions) ? $legacy_latest_versions : array();
+    }
+
+    private function angelleye_get_latest_versions_meta() {
+        $meta = get_transient('angelleye_helper_latest_versions_meta');
+        return is_array($meta) ? $meta : array();
+    }
+
+    private function angelleye_set_latest_versions_meta($meta) {
+        if (!is_array($meta)) {
+            return;
+        }
+
+        set_transient('angelleye_helper_latest_versions_meta', $meta, 7 * DAY_IN_SECONDS);
+
+        $latest_versions = array();
+        foreach ($meta as $product_id => $details) {
+            if (isset($details['latest_version'])) {
+                $latest_versions[sanitize_key($product_id)] = $details['latest_version'];
+            }
+        }
+        set_transient('angelleye_helper_latest_versions', $latest_versions, 7 * DAY_IN_SECONDS);
+    }
+
+    private function angelleye_get_plugin_definition($product_id) {
+        $plugin_list = angelleye_plugin_list();
+        $normalized_product_id = sanitize_key($product_id);
+        if (!is_array($plugin_list) || empty($plugin_list)) {
+            return false;
+        }
+
+        foreach ($plugin_list as $plugin) {
+            if (isset($plugin['plugin_url']) && sanitize_key($plugin['plugin_url']) === $normalized_product_id) {
+                return $plugin;
+            }
+        }
+
+        return false;
+    }
+
+    private function angelleye_get_sync_candidates() {
+        $plugin_list = angelleye_plugin_list();
+        $meta = $this->angelleye_get_latest_versions_meta();
+        $candidates = array();
+        $now = time();
+        $fresh_window = DAY_IN_SECONDS;
+
+        if (!is_array($plugin_list) || empty($plugin_list)) {
+            return $candidates;
+        }
+
+        foreach ($plugin_list as $plugin) {
+            if (!isset($plugin['plugin_url']) || empty($plugin['plugin_url'])) {
+                continue;
+            }
+
+            $product_id = sanitize_key($plugin['plugin_url']);
+            $has_latest = isset($meta[$product_id]['latest_version']) && '' !== $meta[$product_id]['latest_version'] && '-' !== $meta[$product_id]['latest_version'];
+            $last_synced = isset($meta[$product_id]['last_synced']) ? (int) $meta[$product_id]['last_synced'] : 0;
+            $is_fresh = $last_synced > 0 && ( $now - $last_synced ) < $fresh_window;
+
+            if (!$has_latest || !$is_fresh) {
+                $candidates[] = $product_id;
+            }
+        }
+
+        return $candidates;
+    }
+
+    private function angelleye_sync_latest_version_for_product($product_id, $force = false) {
+        $product_id = sanitize_key($product_id);
+        $plugin = $this->angelleye_get_plugin_definition($product_id);
+        if (!$plugin) {
+            return array(
+                'product_id' => $product_id,
+                'latest_version' => '-',
+                'status' => 'not_found',
+            );
+        }
+
+        $meta = $this->angelleye_get_latest_versions_meta();
+        $now = time();
+        $fresh_window = DAY_IN_SECONDS;
+
+        if (!$force && isset($meta[$product_id]['last_synced']) && ( $now - (int) $meta[$product_id]['last_synced'] ) < $fresh_window) {
+            return array(
+                'product_id' => $product_id,
+                'latest_version' => isset($meta[$product_id]['latest_version']) ? $meta[$product_id]['latest_version'] : '-',
+                'status' => 'skipped',
+                'last_synced' => (int) $meta[$product_id]['last_synced'],
+            );
+        }
+
+        $product_file_path = $this->angelleye_get_product_file_path($product_id);
+        $current_version = $this->angelleye_get_plugin_version($product_id);
+        $license_data = $this->angelleye_is_key_activated($product_id);
+        $license_hash = (is_array($license_data) && isset($license_data[2])) ? $license_data[2] : '';
+        $plugin_name_for_request = !empty($product_file_path) ? $product_file_path : $product_id;
+        $file_id = !empty($license_hash) ? '101' : '999';
+
+        $payload = $this->api->angelleye_get_plugin_update_payload(
+            $plugin_name_for_request,
+            $product_id,
+            $current_version,
+            $file_id,
+            $license_hash
+        );
+
+        $latest_version = '-';
+        if (is_object($payload)) {
+            if (isset($payload->new_version) && !empty($payload->new_version)) {
+                $latest_version = $payload->new_version;
+            } elseif (isset($payload->version) && !empty($payload->version)) {
+                $latest_version = $payload->version;
+            }
+        }
+
+        $meta[$product_id] = array(
+            'latest_version' => $latest_version,
+            'last_synced' => $now,
+        );
+        $this->angelleye_set_latest_versions_meta($meta);
+
+        return array(
+            'product_id' => $product_id,
+            'latest_version' => $latest_version,
+            'status' => 'synced',
+            'last_synced' => $now,
+        );
+    }
+
+    private function angelleye_build_latest_versions_from_endpoint() {
+        $latest_versions = array();
+        $plugin_list = angelleye_plugin_list();
+
+        if (!is_array($plugin_list) || empty($plugin_list)) {
+            set_transient('angelleye_helper_latest_versions', $latest_versions, 12 * HOUR_IN_SECONDS);
+            return $latest_versions;
+        }
+
+        foreach ($plugin_list as $plugin) {
+            if (!isset($plugin['plugin_url'])) {
+                continue;
+            }
+
+            $product_id = $plugin['plugin_url'];
+            $product_file_path = $this->angelleye_get_product_file_path($product_id);
+            $current_version = $this->angelleye_get_plugin_version($product_id);
+            $license_data = $this->angelleye_is_key_activated($product_id);
+            $license_hash = (is_array($license_data) && isset($license_data[2])) ? $license_data[2] : '';
+
+            $plugin_name_for_request = !empty($product_file_path) ? $product_file_path : $product_id;
+            $file_id = !empty($license_hash) ? '101' : '999';
+
+            $payload = $this->api->angelleye_get_plugin_update_payload(
+                $plugin_name_for_request,
+                $product_id,
+                $current_version == '-' ? '2.0.0' : $current_version,
+                $file_id,
+                $license_hash
+            );
+
+            $latest_version = '-';
+            if (is_object($payload)) {
+                if (isset($payload->new_version) && !empty($payload->new_version)) {
+                    $latest_version = $payload->new_version;
+                } elseif (isset($payload->version) && !empty($payload->version)) {
+                    $latest_version = $payload->version;
+                }
+            }
+
+            $latest_versions[$product_id] = $latest_version;
+        }
+
+        $meta = array();
+        $now = time();
+        foreach ($latest_versions as $product_id => $version) {
+            $meta[$product_id] = array(
+                'latest_version' => $version,
+                'last_synced' => $now,
+            );
+        }
+
+        $this->angelleye_set_latest_versions_meta($meta);
+        return $latest_versions;
+    }
+
+    private function angelleye_extract_latest_version_from_updates($updates, $product_file_path) {
+        if (!is_object($updates) || empty($product_file_path)) {
+            return '-';
+        }
+
+        if (isset($updates->response[$product_file_path]) && isset($updates->response[$product_file_path]->new_version) && !empty($updates->response[$product_file_path]->new_version)) {
+            return $updates->response[$product_file_path]->new_version;
+        }
+
+        if (isset($updates->no_update[$product_file_path]) && isset($updates->no_update[$product_file_path]->new_version) && !empty($updates->no_update[$product_file_path]->new_version)) {
+            return $updates->no_update[$product_file_path]->new_version;
+        }
+
+        if (isset($updates->checked[$product_file_path]) && !empty($updates->checked[$product_file_path])) {
+            return $updates->checked[$product_file_path];
+        }
+
+        return '-';
+    }
+
+    public function angelleye_maybe_refresh_plugin_updates($force = false) {
+        if (!is_admin() || !current_user_can('update_plugins')) {
+            return;
+        }
+
+        if (!isset($_GET['page']) || 'angelleye-helper' !== $_GET['page']) {
+            return;
+        }
+
+        $refresh_key = 'angelleye_helper_updates_last_refresh';
+        $refresh_window = 5 * MINUTE_IN_SECONDS;
+
+        if (!$force) {
+            $last_refresh = (int) get_transient($refresh_key);
+            if (!empty($last_refresh) && (time() - $last_refresh) < $refresh_window) {
+                return;
+            }
+        }
+
+        if (!function_exists('wp_update_plugins')) {
+            require_once ABSPATH . 'wp-includes/update.php';
+        }
+
+        wp_update_plugins();
+        set_transient($refresh_key, time(), 10 * MINUTE_IN_SECONDS);
     }
     
     public function angelleye_is_key_activated($product_id) {
@@ -977,15 +1313,13 @@ class AngellEYE_Updater_Admin {
     }
     
     public function angelleye_get_product_file_path($product_id) {
-        $plugins = get_plugins();
-        if(!empty($plugins)) {
-            foreach ($plugins as $key => $value) {
-                if($value['TextDomain'] == $product_id) {
-                    return $key;
-                }
-            }
+        $plugin = $this->angelleye_find_plugin_by_product_id($product_id);
+
+        if ($plugin && !empty($plugin['file'])) {
+            return $plugin['file'];
         }
-        return $product_id;
+
+        return '';
     }
     
     public function angelleye_is_plugin_activated($product_id) {
@@ -1007,6 +1341,9 @@ class AngellEYE_Updater_Admin {
         if(isset($_GET['cache-refresh'])) {
             delete_transient('license_key_status_check');
             delete_site_transient( 'update_plugins' );
+            delete_transient('angelleye_helper_updates_last_refresh');
+            delete_transient('angelleye_helper_latest_versions');
+            delete_transient('angelleye_helper_latest_versions_meta');
             delete_site_option('angelleye_helper_dismiss_activation_notice');
             $angelleye_helper_fresh_notice = '<div id="message" class="updated notice is-dismissible"><p><strong>' . esc_html( __( 'Caches refreshed successfully.', 'angelleye-updater' ) ) . '</strong></p></div>';
             set_transient( 'angelleye_helper_fresh_notice', $angelleye_helper_fresh_notice, HOUR_IN_SECONDS );

--- a/admin/class-angelleye-updater-admin.php
+++ b/admin/class-angelleye-updater-admin.php
@@ -1171,14 +1171,7 @@ class AngellEYE_Updater_Admin {
             $license_hash
         );
 
-        $latest_version = '-';
-        if (is_object($payload)) {
-            if (isset($payload->new_version) && !empty($payload->new_version)) {
-                $latest_version = $payload->new_version;
-            } elseif (isset($payload->version) && !empty($payload->version)) {
-                $latest_version = $payload->version;
-            }
-        }
+        $latest_version = $this->angelleye_resolve_latest_version_from_payload($payload, $current_version);
 
         $meta[$product_id] = array(
             'latest_version' => $latest_version,
@@ -1225,14 +1218,7 @@ class AngellEYE_Updater_Admin {
                 $license_hash
             );
 
-            $latest_version = '-';
-            if (is_object($payload)) {
-                if (isset($payload->new_version) && !empty($payload->new_version)) {
-                    $latest_version = $payload->new_version;
-                } elseif (isset($payload->version) && !empty($payload->version)) {
-                    $latest_version = $payload->version;
-                }
-            }
+            $latest_version = $this->angelleye_resolve_latest_version_from_payload($payload, $current_version);
 
             $latest_versions[$product_id] = $latest_version;
         }
@@ -1248,6 +1234,32 @@ class AngellEYE_Updater_Admin {
 
         $this->angelleye_set_latest_versions_meta($meta);
         return $latest_versions;
+    }
+
+    private function angelleye_resolve_latest_version_from_payload($payload, $current_version = '-') {
+        // var_dump($payload, $current_version);
+        $latest_version = '-';
+
+        if (is_object($payload)) {
+            if (isset($payload->new_version) && !empty($payload->new_version)) {
+                $latest_version = $payload->new_version;
+            } elseif (isset($payload->version) && !empty($payload->version)) {
+                $latest_version = $payload->version;
+            } elseif (isset($payload->success) && true === $payload->success) {
+                // API success without explicit version means current version is already latest.
+                $latest_version = (!empty($current_version) && '-' !== $current_version) ? $current_version : '-';
+            }
+        } elseif (is_array($payload)) {
+            if (isset($payload['new_version']) && !empty($payload['new_version'])) {
+                $latest_version = $payload['new_version'];
+            } elseif (isset($payload['version']) && !empty($payload['version'])) {
+                $latest_version = $payload['version'];
+            } elseif (isset($payload['success']) && true === $payload['success']) {
+                $latest_version = (!empty($current_version) && '-' !== $current_version) ? $current_version : '-';
+            }
+        }
+
+        return $latest_version;
     }
 
     private function angelleye_extract_latest_version_from_updates($updates, $product_file_path) {

--- a/admin/css/angelleye-updater-admin.css
+++ b/admin/css/angelleye-updater-admin.css
@@ -179,6 +179,32 @@ color:
     margin-top: 20px;
 }
 
+.ae-latest-version-wrap {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.ae-latest-version-loader {
+    color: #2271b1;
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
+}
+
+.ae-latest-version-loader.is-spinning {
+    animation: ae-spin 1s linear infinite;
+}
+
+@keyframes ae-spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+
 /**
  * WP Rollback Styles
  */

--- a/admin/css/angelleye-updater-admin.css
+++ b/admin/css/angelleye-updater-admin.css
@@ -366,3 +366,7 @@ color:
 .angelleye-version-list{
 	width: 800px;
 }
+
+.mx-w-100-p {
+    max-width: 100%;
+}

--- a/admin/js/angelleye-updater-admin.js
+++ b/admin/js/angelleye-updater-admin.js
@@ -1,4 +1,115 @@
 jQuery(document).ready(function ($) {
+    function aeUpdateSyncStatus(message, type) {
+        var $status = $('#ae-version-sync-status');
+        if (!$status.length) {
+            return;
+        }
+
+        $status.removeClass('notice-info notice-success notice-warning notice-error');
+        $status.addClass('notice-' + (type || 'info')).show();
+        $status.html('<p>' + message + '</p>');
+    }
+
+    function aeUpdateLatestVersionCell(productId, latestVersion) {
+        if (!productId) {
+            return;
+        }
+
+        var $wrap = $('.ae-latest-version-wrap[data-product-id="' + productId + '"]');
+        if ($wrap.length) {
+            $wrap.find('.ae-latest-version').text(latestVersion || '-');
+        }
+    }
+
+    function aeToggleLatestVersionLoader(productId, show) {
+        if (!productId) {
+            return;
+        }
+
+        var $wrap = $('.ae-latest-version-wrap[data-product-id="' + productId + '"]');
+        if (!$wrap.length) {
+            return;
+        }
+
+        var $loader = $wrap.find('.ae-latest-version-loader');
+        if (show) {
+            $loader.addClass('is-spinning').show();
+        } else {
+            $loader.removeClass('is-spinning').hide();
+        }
+    }
+
+    function aeRunLatestVersionSyncQueue() {
+        if (typeof WTHelper === 'undefined' || !Array.isArray(WTHelper.sync_candidates)) {
+            return;
+        }
+
+        if (!WTHelper.sync_candidates.length) {
+            aeUpdateSyncStatus('All latest versions are fresh (last 24h).', 'success');
+            return;
+        }
+
+        var queue = WTHelper.sync_candidates.slice(0);
+        var total = queue.length;
+        var completed = 0;
+        var synced = 0;
+        var skipped = 0;
+        var failed = 0;
+
+        aeUpdateSyncStatus('Checking latest versions... (0/' + total + ')', 'info');
+
+        function next() {
+            if (!queue.length) {
+                var type = failed > 0 ? 'warning' : 'success';
+                aeUpdateSyncStatus(
+                    'Latest version sync finished. Synced: ' + synced + ', Skipped (<24h): ' + skipped + ', Failed: ' + failed + '.',
+                    type
+                );
+                return;
+            }
+
+            var productId = queue.shift();
+            aeToggleLatestVersionLoader(productId, true);
+
+            $.post(WTHelper.ajax_url, {
+                action: 'angelleye_sync_latest_version',
+                security: WTHelper.sync_latest_nonce,
+                product_id: productId
+            }).done(function (response) {
+                completed++;
+
+                if (response && response.success && response.data) {
+                    var status = response.data.status || '';
+                    var latestVersion = response.data.latest_version || '-';
+                    aeUpdateLatestVersionCell(productId, latestVersion);
+
+                    if (status === 'synced') {
+                        synced++;
+                    } else if (status === 'skipped') {
+                        skipped++;
+                    } else {
+                        failed++;
+                    }
+                } else {
+                    failed++;
+                }
+            }).fail(function () {
+                completed++;
+                failed++;
+            }).always(function () {
+                aeToggleLatestVersionLoader(productId, false);
+                aeUpdateSyncStatus('Checking latest versions... (' + completed + '/' + total + ')', 'info');
+                next();
+            });
+        }
+
+        next();
+    }
+
+    if ($('body').hasClass('dashboard_page_angelleye-helper') || $('body').hasClass('index_page_angelleye-helper-network')) {
+        aeRunLatestVersionSyncQueue();
+    }
+
     // Check if form is submitted and override
     $('.dashboard_page_angelleye-helper #activate-products').submit(function (event) {
         var license_keys_object = new Array();

--- a/includes/class-angelleye-updater-api.php
+++ b/includes/class-angelleye-updater-api.php
@@ -333,15 +333,6 @@ class AngellEYE_Updater_API {
             'domain_name' => esc_url(home_url('/')),
             'url' => esc_url(home_url('/'))
         ));
-        // var_dump($request, array(
-        //     'plugin_name' => $plugin_name,
-        //     'product_id' => $product_id,
-        //     'version' => $version,
-        //     'file_id' => $file_id,
-        //     'license_hash' => $license_hash,
-        //     'domain_name' => esc_url(home_url('/')),
-        //     'url' => esc_url(home_url('/'))
-        // )); die;
         if (is_object($request) && isset($request->payload) && is_object($request->payload)) {
             return $request->payload;
         }

--- a/includes/class-angelleye-updater-api.php
+++ b/includes/class-angelleye-updater-api.php
@@ -230,7 +230,13 @@ class AngellEYE_Updater_API {
             $url .= '&action=' . $endpoint;
         }
 
-        $response = wp_remote_get($url, $args);
+        if ('GET' == strtoupper($method)){
+            $response = wp_remote_get($url, $args);
+        } else {
+            $response = wp_remote_post($url, $args);
+        }
+
+        // var_dump($response, $url, $args); die;
 
         if (is_wp_error($response)) {
             $error_string = $response->get_error_message();
@@ -314,5 +320,32 @@ class AngellEYE_Updater_API {
         $response = false;
         $request = $this->request('get_tags', array('plugin_name' => $param['product_name'], 'version' => $param['current_version'], 'domain_name' => esc_url(home_url('/'))));
         return $request;
+    }
+
+    public function angelleye_get_plugin_update_payload($plugin_name, $product_id, $version = '1.0.0', $file_id = '999', $license_hash = '') {
+        // var_dump($plugin_name); return false;
+        $request = $this->request('pluginupdatecheck', array(
+            'plugin_name' => $plugin_name,
+            'product_id' => $product_id,
+            'version' => $version,
+            'file_id' => $file_id,
+            'license_hash' => $license_hash,
+            'domain_name' => esc_url(home_url('/')),
+            'url' => esc_url(home_url('/'))
+        ));
+        // var_dump($request, array(
+        //     'plugin_name' => $plugin_name,
+        //     'product_id' => $product_id,
+        //     'version' => $version,
+        //     'file_id' => $file_id,
+        //     'license_hash' => $license_hash,
+        //     'domain_name' => esc_url(home_url('/')),
+        //     'url' => esc_url(home_url('/'))
+        // )); die;
+        if (is_object($request) && isset($request->payload) && is_object($request->payload)) {
+            return $request->payload;
+        }
+
+        return false;
     }
 }

--- a/includes/class-angelleye-updater-api.php
+++ b/includes/class-angelleye-updater-api.php
@@ -346,6 +346,6 @@ class AngellEYE_Updater_API {
             return $request->payload;
         }
 
-        return false;
+        return $request ? $request : false;
     }
 }

--- a/includes/class-angelleye-updater-licenses-table.php
+++ b/includes/class-angelleye-updater-licenses-table.php
@@ -125,6 +125,8 @@ class AngellEYE_Updater_Licenses_Table extends WP_List_Table {
             case 'product':
             case 'product_status':
             case 'product_version':
+            case 'installed_version':
+            case 'latest_version':
                 return $item[$column_name];
                 break;
         }
@@ -151,7 +153,8 @@ class AngellEYE_Updater_Licenses_Table extends WP_List_Table {
     public function get_columns() {
         $columns = array(
             'product_name' => __('Product', 'angelleye-updater'),
-            'product_version' => __('Version', 'angelleye-updater'),
+            'installed_version' => __('Installed Version', 'angelleye-updater'),
+            'latest_version' => __('Latest Version', 'angelleye-updater'),
             'license_key' => __('License Key', 'angelleye-updater'),
             'product_status' => __('Action', 'angelleye-updater'),
             'plugin_status' => __('Status', 'angelleye-updater'),
@@ -202,13 +205,37 @@ class AngellEYE_Updater_Licenses_Table extends WP_List_Table {
     // End column_license_key()
 
     /**
+     * Content for the "installed_version" column.
+     * @param  array  $item The current item.
+     * @since  1.0.0
+     * @return string       The content of this column.
+     */
+    public function column_installed_version($item) {
+        $version = isset($item['installed_version']) ? $item['installed_version'] : '-';
+        return wpautop($version);
+    }
+
+    /**
+     * Content for the "latest_version" column.
+     * @param  array  $item The current item.
+     * @since  1.0.0
+     * @return string       The content of this column.
+     */
+    public function column_latest_version($item) {
+        $version = isset($item['latest_version']) ? $item['latest_version'] : '-';
+        $product_id = isset($item['product_id']) ? $item['product_id'] : '';
+        return '<span class="ae-latest-version-wrap" data-product-id="' . esc_attr($product_id) . '"><span class="ae-latest-version">' . esc_html($version) . '</span><span class="dashicons dashicons-update ae-latest-version-loader" aria-hidden="true" style="display:none;"></span></span>';
+    }
+
+    /**
      * Content for the "product_version" column.
      * @param  array  $item The current item.
      * @since  1.0.0
      * @return string       The content of this column.
      */
     public function column_product_version($item) {
-        return wpautop($item['product_version']);
+        $version = isset($item['installed_version']) ? $item['installed_version'] : ( isset($item['product_version']) ? $item['product_version'] : '-' );
+        return wpautop($version);
     }
 
     // End column_product_version()

--- a/includes/class-angelleye-updater-licenses-table.php
+++ b/includes/class-angelleye-updater-licenses-table.php
@@ -194,7 +194,7 @@ class AngellEYE_Updater_Licenses_Table extends WP_List_Table {
                 return $more_info;
             } elseif ($item['is_paid'] == true) {
                 $response = '';
-                $response .= '<input name="license_keys[' . esc_attr($item['product_file_path']) . ']" id="license_keys-' . esc_attr($item['product_file_path']) . '" type="text" value="" size="37" aria-required="true" placeholder="' . esc_attr(__('Enter license key here', 'angelleye-updater')) . '" />' . "\n";
+                $response .= '<input class="mx-w-100-p" name="license_keys[' . esc_attr($item['product_file_path']) . ']" id="license_keys-' . esc_attr($item['product_file_path']) . '" type="text" value="" size="37" aria-required="true" placeholder="' . esc_attr(__('Enter license key here', 'angelleye-updater')) . '" />' . "\n";
                 return $response;
             } else {
                 return __('FREE', 'angelleye-updater');

--- a/includes/class-angelleye-updater-update-checker.php
+++ b/includes/class-angelleye-updater-update-checker.php
@@ -84,22 +84,22 @@ class AngellEYE_Updater_Update_Checker {
 	    if (empty($transient->checked))
 		    return $transient;
 
+	    /**
+	     * Retrieve plugin information through WP function
+	     */
+	    $plugin_info_data = get_plugin_data(WP_PLUGIN_DIR . '/'. $this->file, false, false );
+	    if(!is_array($plugin_info_data) || !isset($plugin_info_data['Version'])){
+		    $response = new stdClass();
+		    $response->slug = $this->product_id;
+		    $transient->no_update[$this->file] = $response;
+		    return $transient;
+	    }
+	    $current_plugin_version = !empty($plugin_info_data['Version']) ? $plugin_info_data['Version'] : '1.0.0';
+
 
 	    if(isset(self::$update_responses[$this->file])){
 		    $response = self::$update_responses[$this->file];
 	    }else {
-		    /**
-		     * Retrieve plugin information through WP function
-		     */
-		    $plugin_info_data = get_plugin_data(WP_PLUGIN_DIR . '/'. $this->file, false, false );
-		    if(!is_array($plugin_info_data) || !isset($plugin_info_data['Version'])){
-			    $response = new stdClass ();
-			    $response->slug = $this->product_id;
-			    $transient->no_update[ $this->file ] = $response;
-			    return $transient;
-		    }
-		    $current_plugin_version = !empty($plugin_info_data['Version']) ? $plugin_info_data['Version'] : '1.0.0';
-
 		    $args = array(
 			    'request'           => 'pluginupdatecheck',
 			    'plugin_name'       => $this->file,
@@ -123,18 +123,38 @@ class AngellEYE_Updater_Update_Checker {
             if (isset($response->errors) && isset($response->errors->woo_updater_api_license_deactivated)) {
                 add_action('admin_notices', array($this, 'error_notice_for_deactivated_plugin'));
             } else {
+                if (!is_object($response)) {
+                    $response = new stdClass();
+                }
+
                 if( isset($response->icons) ) {
                     $response->icons = (array) $response->icons;
                 }
                 if( isset($response->banners) ) {
                     $response->banners = (array) $response->banners;
                 }
-                $transient->response[$this->file] = $response;
+
+                // Normalize update object for WordPress core update screens.
+                $response->plugin = $this->file;
+                if (!isset($response->slug) || empty($response->slug)) {
+                    $slug = dirname($this->file);
+                    $response->slug = ('.' !== $slug && !empty($slug)) ? $slug : $this->product_id;
+                }
+                if ((!isset($response->new_version) || empty($response->new_version)) && isset($response->version) && !empty($response->version)) {
+                    $response->new_version = $response->version;
+                }
+
+                if (isset($response->new_version) && !empty($response->new_version) && version_compare($response->new_version, $current_plugin_version, '>')) {
+                    $transient->response[$this->file] = $response;
+                } else {
+                    $transient->no_update[$this->file] = $response;
+                }
             }
         } else {
             $response = new stdClass ();
             $response->slug = $this->product_id;
-            $transient->no_update[ $this->file ] = $response;
+            $response->plugin = $this->file;
+            $transient->no_update[$this->file] = $response;
         }
 
         return $transient;

--- a/screens/screen-manage.php
+++ b/screens/screen-manage.php
@@ -1,8 +1,13 @@
 <?php if (!defined('ABSPATH')) exit; // Exit if accessed directly    ?>
 
 <div id="col-container" class="about-wrap">
-    <div class="ag-helper">
-        <a class="button button-update" href="<?php echo esc_url( $refresh_url ); ?>"><span class="dashicons dashicons-image-rotate"></span> <?php _e( 'Update', 'woocommerce' ); ?></a>
+    <div class="ag-helper" style="display: flex;align-items:center;gap:10px;">
+        <div style="flex: 1;">
+            <p style="font-size: 13px; margin: 0;">Use Refresh Plugin Updates to retrieve the latest version information for AngellEye plugins. Once refreshed, you can install available updates from the WordPress Updates page.</p>
+        </div>
+        <div>
+        <a style="display: inline-block;padding: 5px;" class="button button-update" href="<?php echo esc_url( $refresh_url ); ?>"><span class="dashicons dashicons-image-rotate"></span> <?php _e( 'Refresh Plugin Updates', 'woocommerce' ); ?></a>
+        </div>
     </div>
     <div id="ae-version-sync-status" class="notice notice-info inline" style="display:none;"></div>
    
@@ -17,7 +22,7 @@
             $this->list_table->prepare_items();
             $this->list_table->display();
             wp_nonce_field( 'angelleye-activate-license', 'angelleye-helper-nonce' ); 
-            submit_button(__('Activate Products', 'angelleye-updater'), 'button-primary');
+            submit_button(__('Save & Activate License', 'angelleye-updater'), 'button-primary');
             ?>
         </form>
     </div><!--/.col-wrap-->

--- a/screens/screen-manage.php
+++ b/screens/screen-manage.php
@@ -4,6 +4,7 @@
     <div class="ag-helper">
         <a class="button button-update" href="<?php echo esc_url( $refresh_url ); ?>"><span class="dashicons dashicons-image-rotate"></span> <?php _e( 'Update', 'woocommerce' ); ?></a>
     </div>
+    <div id="ae-version-sync-status" class="notice notice-info inline" style="display:none;"></div>
    
     <div class="col-wrap">
         <form id="activate-products" method="post" action="" class="validate">


### PR DESCRIPTION
## Summary
Improves the AngellEye updater experience by making plugin update information clearer and ensuring WordPress displays the correct update data.

## Problem
The current AngellEye updater can be confusing because the latest plugin version may appear inconsistently. This can cause users to repeatedly click the update button even though no update is actually available.

Additionally, the WordPress **Dashboard → Updates** page may not always reflect the latest plugin update information due to cached data.

## Solution
This PR improves the updater behavior by exposing the latest plugin version directly in the UI and ensuring the WordPress update cache is refreshed when requested.

## Changes
- Adds **Latest Version** column on the AngellEye Helper page.
- Hooks the **Update button** to refresh the WordPress update cache.
- Fixes the **updated plugin information visibility** on the WordPress Updates page.
- Adds a helper notice explaining how to refresh plugin update data.

## Testing
1. Navigate to **AngellEye Helper → Plugins** page.
2. Click **Refresh Plugin Updates**.
3. Verify the **Latest Version** column updates correctly.
4. Go to **Dashboard → Updates**.
5. Confirm that available plugin updates are listed correctly.

## Result
- Users can clearly see installed vs latest plugin versions.
- Update information stays synchronized with the WordPress updates system.
- Reduces confusion around plugin update availability.